### PR TITLE
feat: add --tables flag to limit which tables are exported

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,16 @@ Example usage
 ./export.py --base-url <SELFHOSTED_SPACELIFT_URL> --api-key-id <EXPORT_API_KEY_ID> --api-key-secret <EXPORT_API_KEY_SECRET> --start-date <YYYY-MM-DD> --end-date <YYYY-MM-DD> --skip-tls-verification --batch-size 7 --send-to-spacelift
 ```
 
+### Limiting which tables are exported
+
+By default the export covers the full set of tables. Pass `--tables` with a comma-separated list to restrict the dump — for example to ship only what billing needs:
+
+```bash
+./export.py --base-url <SELFHOSTED_SPACELIFT_URL> --api-key-id <EXPORT_API_KEY_ID> --api-key-secret <EXPORT_API_KEY_SECRET> --start-date <YYYY-MM-DD> --end-date <YYYY-MM-DD> --tables logins,heartbeats,daily_worker_usages --send-to-spacelift
+```
+
+Account details are always part of the response envelope and do not need to be listed. Unknown table names are rejected by the server, which returns the full list of accepted values in its error.
+
 For more details run
 
 ```bash

--- a/export.py
+++ b/export.py
@@ -7,6 +7,7 @@ import requests
 import time
 import datetime
 import json
+import urllib.parse
 
 requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
 
@@ -73,8 +74,10 @@ def validate_date(date_str):
     if not match:
         raise ValueError(f"Invalid date format: {date_str}, expected format: YYYY-MM-DD")
 
-def export_single(base_url, api_key_id, api_key_secret, current_start, current_end, skip_tls_verification, send_to_spacelift):
+def export_single(base_url, api_key_id, api_key_secret, current_start, current_end, skip_tls_verification, send_to_spacelift, tables):
     url = f"{base_url}/selfhosted/metrics?start_timestamp={current_start}&end_timestamp={current_end}"
+    if tables:
+        url += f"&tables={urllib.parse.quote(tables)}"
     try:
         logging.info("Requesting API Token")
         token = authenticate(base_url, api_key_id, api_key_secret, skip_tls_verification)
@@ -91,7 +94,7 @@ def export_single(base_url, api_key_id, api_key_secret, current_start, current_e
     except requests.RequestException as e:
         logging.error(f"Request error: {e}")
 
-def export(base_url, api_key_id, api_key_secret, start_date_str, end_date_str, batch_days, skip_tls_verification, send_to_spacelift):
+def export(base_url, api_key_id, api_key_secret, start_date_str, end_date_str, batch_days, skip_tls_verification, send_to_spacelift, tables):
     try:
         validate_date(start_date_str)
         validate_date(end_date_str)
@@ -110,7 +113,7 @@ def export(base_url, api_key_id, api_key_secret, start_date_str, end_date_str, b
         if current_end > end_timestamp:
             current_end = end_timestamp
 
-        export_single(base_url, api_key_id, api_key_secret, current_start, current_end, skip_tls_verification, send_to_spacelift)
+        export_single(base_url, api_key_id, api_key_secret, current_start, current_end, skip_tls_verification, send_to_spacelift, tables)
 
         # Move to the next batch
         current_start = current_end
@@ -140,9 +143,10 @@ def main():
     parser.add_argument('--batch-size', default=7, type=int, help="Number of days to export in a single batch")
     parser.add_argument('--skip-tls-verification', action='store_true', help="Skip TLS verification")
     parser.add_argument('--send-to-spacelift', action='store_true', help="Send data directly to Spacelift instead of saving it locally")
+    parser.add_argument('--tables', default=None, help="Comma-separated list of tables to export (e.g. `logins,heartbeats,daily_worker_usages`). When omitted the full set of tables is exported. Unknown table names are rejected by the server, which returns the list of valid choices.")
     args = parser.parse_args()
 
-    export(args.base_url, args.api_key_id, args.api_key_secret, args.start_date, args.end_date, args.batch_size, args.skip_tls_verification, args.send_to_spacelift)
+    export(args.base_url, args.api_key_id, args.api_key_secret, args.start_date, args.end_date, args.batch_size, args.skip_tls_verification, args.send_to_spacelift, args.tables)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Forwards the optional `tables` query parameter that the self-hosted metrics endpoint now accepts, so callers (typically a scheduled wrapper around this script) can request a subset of the dump — e.g. only what billing needs — instead of the full export. Omitting the flag preserves the existing full-export behaviour.

Depends on the backend change in [spacelift-io/backend#14079](https://github.com/spacelift-io/backend/pull/14079); without that PR merged the server will reject the new query parameter.

Resolves [CU-869d5pq63](https://app.clickup.com/t/869d5pq63).